### PR TITLE
Updated to match json-api spec on one to many relationships

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -14,6 +14,11 @@ var errors = require("./errors")
  * @param {Waterline.Collection} collection to base the payload on.
  */
 function JSONAPIModel(values, collection) {
+  // prevent app from crashing if values is undefined
+  if (!values) {
+    return this
+  }
+
   // Check we got an instance of JSONAPIModel.
   if (!(this instanceof JSONAPIModel)) {
     return new JSONAPIModel(values, collection)

--- a/lib/relationships.js
+++ b/lib/relationships.js
@@ -15,6 +15,18 @@ function generated_related_payload(identity, from) {
 }
 
 /**
+ * Map target values and wrap in a data object
+ * @param  {String} identity of the collection as the type.
+ * @param  {Object} target object to map
+ * @return {Object} mapped data object for relationships
+ */
+function map_target_values(identity, target) {
+  return {
+    data: target.map(value => generated_related_payload(identity, value))
+  }
+}
+
+/**
  * Discover relationships within this value set
  * that are declared in the blueprint so we can
  * pull them out and apply them to the right key
@@ -42,17 +54,9 @@ function discover_relationships(values, model) {
       return
     }
 
-    // To comply with the spec, if there's only one value
-    // it should not be an array.
-    if (Array.isArray(target) && target.length === 1) {
-      target = target[0]
-    }
-
     // If it's an array, map over the target values.
     if (Array.isArray(target)) {
-      relationships[association] = target.map(function(value) {
-        return generated_related_payload(identity, value)
-      })
+      relationships[association] = map_target_values(identity, target);
     }
     // Otherwise, adhere to the spec and have a single object.
     else {


### PR DESCRIPTION
Hi friend! 

First of all thanks for building this, love it! Someone on my team ran into an issue when integrating our web service with our Ember.js App (2.x consumes JSON-API out of the box). We have a one to many relationship in our data model on both the server and client side. Turns out the waterline-jsonapi module was actually transforming this into a one to one representation when the collection only contained one element (on the many side of the association) causing Ember to freak out. 

We wrote a custom serializer on the ember-side for now as a workaround.  

I noticed your issue regarding this #1 however I think it may be a mis interpretation of the spec (I did that too at first). 

According to the JSON-API spec resource linkage MUST be represented as one of the following:
* null for empty to-one relationships.
* an empty array ([]) for empty to-many relationships.
* a single resource identifier object for non-empty to-one relationships.
* an array of resource identifier objects for non-empty to-many relationships.

Notice bullet 3 "a single resource identifier object for non-empty to-one relationships", that's for non empty *to-one* relationships. If we have an array I think it's safe to assume this is a *to-many* relationship. See: http://jsonapi.org/format/#document-resource-object-related-resource-links

Thanks! 
Dylan
